### PR TITLE
Removing readback file and verbose settings

### DIFF
--- a/vivadocompile.tcl
+++ b/vivadocompile.tcl
@@ -146,10 +146,6 @@ current_run -synthesis [get_runs synth_1]
 
 set_property strategy "Vivado Implementation Defaults" [get_runs impl_1]
 
-set obj [get_runs impl_1]
-set_property "steps.write_bitstream.args.readback_file" "0" $obj
-set_property "steps.write_bitstream.args.verbose" "0" $obj
-
 # set the current impl run
 current_run -implementation [get_runs impl_1]
 


### PR DESCRIPTION
Removing readback_file and verbose disabling to make tcl script compatible with all device families.